### PR TITLE
Fully exposes exoplayer2.analytics in bindings

### DIFF
--- a/ExoPlayer.Core/Transforms/Metadata.xml
+++ b/ExoPlayer.Core/Transforms/Metadata.xml
@@ -101,15 +101,6 @@
     <attr path="/api/package[@name='com.google.android.exoplayer2.audio']/class[@name='AudioRendererEventListener.EventDispatcher']/method[@name='inputFormatChanged' and count(parameter)=1 and parameter[1][@type='com.google.android.exoplayer2.Format']]" name="managedName" >InvokeInputFormatChanged</attr>
     <attr path="/api/package[@name='com.google.android.exoplayer2.audio']/class[@name='AudioRendererEventListener.EventDispatcher']/method[@name='audioTrackUnderrun' and count(parameter)=3 and parameter[1][@type='int'] and parameter[2][@type='long'] and parameter[3][@type='long']]" name="managedName" >InvokeAudioTrackUnderrun</attr>
 
-    <remove-node path="/api/package[@name='com.google.android.exoplayer2.analytics']/interface[@name='AnalyticsListener']/method[@name='onVideoSizeChanged']" />
-    <remove-node path="/api/package[@name='com.google.android.exoplayer2.analytics']/interface[@name='AnalyticsListener']/method[@name='onAudioSessionId']" />
-    <remove-node path="/api/package[@name='com.google.android.exoplayer2.analytics']/interface[@name='AnalyticsListener']/method[@name='onAudioUnderrun']" />
-    <remove-node path="/api/package[@name='com.google.android.exoplayer2.analytics']/interface[@name='AnalyticsListener']/method[@name='onDecoderInitialized']" />
-    <remove-node path="/api/package[@name='com.google.android.exoplayer2.analytics']/interface[@name='AnalyticsListener']/method[@name='onDecoderEnabled']" />
-    <remove-node path="/api/package[@name='com.google.android.exoplayer2.analytics']/interface[@name='AnalyticsListener']/method[@name='onDecoderDisabled']" />
-    <remove-node path="/api/package[@name='com.google.android.exoplayer2.analytics']/interface[@name='AnalyticsListener']/method[@name='onDecoderInputFormatChanged']" />
-    <remove-node path="/api/package[@name='com.google.android.exoplayer2.analytics']/interface[@name='AnalyticsListener']/method[@name='onRenderedFirstFrame']" />
-
     <!-- remove dupes -->
     <!--<attr path="/api/package[@name='com.google.android.exoplayer2.video']/interface[@name='VideoRendererEventListener']/method[@name='onVideoSizeChanged']" name="eventName"></attr>-->
     <!--<attr path="/api/package[@name='com.google.android.exoplayer2.video']/interface[@name='VideoRendererEventListener']/method[@name='onVideoEnabled']" name="eventName"></attr>-->
@@ -132,10 +123,16 @@
     <!--<attr name="type" path="/api/package[@name='com.google.android.exoplayer2.offline']/class[@name='DownloadHelper']/method[@name='getDownloadAction' and count(parameter)=2 and parameter[1][@type='byte[]'] and parameter[2][@type='java.util.List&lt;com.google.android.exoplayer2.offline.TrackKey&gt;']]/parameter[2]" >Java.Util.IList</attr>-->
     <!--<attr name="type" path="/api/package[@name='com.google.android.exoplayer2.offline']/class[@name='ProgressiveDownloadHelper']/method[@name='getDownloadAction' and count(parameter)=2 and parameter[1][@type='byte[]'] and parameter[2][@type='java.util.List&lt;com.google.android.exoplayer2.offline.TrackKey&gt;']]/parameter[2]" >Java.Util.IList</attr>-->
     
-    <!--  Need to remove because Java messes up  -->
-    <remove-node path="/api/package[@name='com.google.android.exoplayer2.analytics']/class[@name='AnalyticsCollector']" />
-    <remove-node path="/api/package[@name='com.google.android.exoplayer2.analytics']/interface[@name='AnalyticsListener']" />
-    <remove-node path="/api/package[@name='com.google.android.exoplayer2.analytics']/class[@name='AnalyticsListener.EventTime']" />
+    <!-- Remove deprecated methods in AnalyticsListener that cause Java to mess up.-->
+    <remove-node path="/api/package[@name='com.google.android.exoplayer2.analytics']/interface[@name='AnalyticsListener']/method[@name='onAudioDecoderInitialized' and count(parameter)=3 and parameter[1][@type='com.google.android.exoplayer2.analytics.AnalyticsListener.EventTime'] and parameter[2][@type='java.lang.String'] and parameter[3][@type='long']]" />
+    <remove-node path="/api/package[@name='com.google.android.exoplayer2.analytics']/interface[@name='AnalyticsListener']/method[@name='onAudioInputFormatChanged' and count(parameter)=2 and parameter[1][@type='com.google.android.exoplayer2.analytics.AnalyticsListener.EventTime'] and parameter[2][@type='com.google.android.exoplayer2.Format']]" />
+    <remove-node path="/api/package[@name='com.google.android.exoplayer2.analytics']/interface[@name='AnalyticsListener']/method[@name='onDrmSessionAcquired' and count(parameter)=1 and parameter[1][@type='com.google.android.exoplayer2.analytics.AnalyticsListener.EventTime']]" />
+    <remove-node path="/api/package[@name='com.google.android.exoplayer2.analytics']/interface[@name='AnalyticsListener']/method[@name='onPositionDiscontinuity' and count(parameter)=2 and parameter[1][@type='com.google.android.exoplayer2.analytics.AnalyticsListener.EventTime'] and parameter[2][@type='int']]" />
+    <remove-node path="/api/package[@name='com.google.android.exoplayer2.analytics']/interface[@name='AnalyticsListener']/method[@name='onVideoDecoderInitialized' and count(parameter)=3 and parameter[1][@type='com.google.android.exoplayer2.analytics.AnalyticsListener.EventTime'] and parameter[2][@type='java.lang.String'] and parameter[3][@type='long']]" />
+    <remove-node path="/api/package[@name='com.google.android.exoplayer2.analytics']/interface[@name='AnalyticsListener']/method[@name='onVideoInputFormatChanged' and count(parameter)=2 and parameter[1][@type='com.google.android.exoplayer2.analytics.AnalyticsListener.EventTime'] and parameter[2][@type='com.google.android.exoplayer2.Format']]" />
+    <remove-node path="/api/package[@name='com.google.android.exoplayer2.analytics']/interface[@name='AnalyticsListener']/method[@name='onVideoSizeChanged' and count(parameter)=5 and parameter[1][@type='com.google.android.exoplayer2.analytics.AnalyticsListener.EventTime'] and parameter[2][@type='int'] and parameter[3][@type='int'] and parameter[4][@type='int'] and parameter[5][@type='float']]" />
+
+    <attr name="return" path="/api/package[@name='com.google.android.exoplayer2']/interface[@name='ExoPlayer']/method[@name='getPlayerError' and count(parameter)=0]">Com.Google.Android.Exoplayer2.PlaybackException</attr>
 
     <!-- Need to remove for AdsLoader -->
     <remove-node path="/api/package[@name='com.google.android.exoplayer2.source.ads']/interface[@name='AdsLoader']/method[@name='handlePrepareError' and count(parameter)=3 and parameter[1][@type='int'] and parameter[2][@type='int'] and parameter[3][@type='java.io.IOException']]" />


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fully exposes ExoPlayer2.Analytics in the current bindings. (Issue: https://github.com/Baseflow/ExoPlayerXamarin/issues/120)

### :arrow_heading_down: What is the current behavior?
Analytics is barely implemented.

### :new: What is the new behavior (if this is a feature change)?
Analytics is fully implemented.

### :boom: Does this PR introduce a breaking change?
Not in current testing as far as I'm aware.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
