### PR TITLE
Fix notification manager listener binding

### DIFF
--- a/ExoPlayer.UI/Transforms/Metadata.xml
+++ b/ExoPlayer.UI/Transforms/Metadata.xml
@@ -2,4 +2,9 @@
 <metadata>
     <!-- Remove Obsolete Duplicate-->
     <remove-node path="/api/package[@name='com.google.android.exoplayer2.ui']/class[@name='StyledPlayerView']/method[@name='setControllerVisibilityListener' and count(parameter)=1 and parameter[1][@type='com.google.android.exoplayer2.ui.StyledPlayerControlView.VisibilityListener']]" />
+
+    <!-- Add NotificationListener methods -->
+
+    <attr path="/api/package[@name='com.google.android.exoplayer2.ui']/interface[@name='PlayerNotificationManager.NotificationListener']/method[@name='onNotificationCancelled' and count(parameter)=2 and parameter[1][@type='int'] and parameter[2][@type='boolean']]" name="abstract">true</attr>
+    <attr path="/api/package[@name='com.google.android.exoplayer2.ui']/interface[@name='PlayerNotificationManager.NotificationListener']/method[@name='onNotificationPosted' and count(parameter)=3 and parameter[1][@type='int'] and parameter[2][@type='android.app.Notification'] and parameter[3][@type='boolean']]" name="abstract">true</attr>
 </metadata>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
The generated PlayerNotificationManager.Listener interface didn't contain methods. 
Due to this, the foreground service in MediaManager was never started.

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
